### PR TITLE
fix: add type definitions module exports and change the package because it makes crashes on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,6 +95,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.github.convertedin:android-pixel-sdk:1.4.3"
+  implementation 'com.github.Scode-Njnjas:android-pixel-sdk:v1.0.1'
 }
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "source": "src/index.ts",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "types": "src/index.d.ts",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./src/index.d.ts",
       "import": "./lib/module/index.js",
       "require": "./lib/commonjs/index.js"
     }


### PR DESCRIPTION
- fix: add type definitions module exports.
- fix: change the package because it makes crashes on Android.